### PR TITLE
fix: warnings in semantic release / npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.github
+.migration-temp
+.logs
+output-*

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tools and utilities for the IBM Cloud Continuous Delivery service and resources",
   "repository": {
     "type": "git",
-    "url": "https://github.com/IBM/continuous-delivery-tools"
+    "url": "git+https://github.com/IBM/continuous-delivery-tools.git"
   },
   "keywords": [
     "ibm"
@@ -24,6 +24,8 @@
     "ora": "^9.0.0",
     "strip-ansi": "^7.1.2"
   },
-  "bin": "./index.js",
+  "bin": {
+    "cd-tools": "index.js"
+  },
   "type": "module"
 }


### PR DESCRIPTION
Fix warnings in release workflow:
```
[8:39:50 PM] [semantic-release] [@semantic-release/npm] › ℹ  Publishing version 1.1.0 to npm registry on dist-tag latest
npm warn gitignore-fallback No .npmignore file found, using .gitignore for file exclusion. Consider creating a .npmignore file to explicitly control published files.
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "bin" was converted to an object
npm warn publish "bin[@ibm-cloud/cd-tools]" was renamed to "bin[cd-tools]"
npm warn publish "bin[cd-tools]" script name index.js was invalid and removed
npm warn publish "repository.url" was normalized to "git+https://github.com/IBM/continuous-delivery-tools.git"
```