### PR TITLE
test: fix tests to no longer use eu-es test toolchains

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -13,14 +13,20 @@ Before running tests, ensure that you have completed the setup steps in the main
     ```bash
     npm install
     ```
-3. **Test configuration**
+3. **Fix node-pty executable**
+
+    macOS only: There is a bug in one of the executables used by `node-pty`, the prebuilt binary is missing the executable flag, causing errors like `Error: posix_spawnp failed.`. You can fix this manually:
+    ```bash
+    chmod +x node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper
+    ```
+4. **Test configuration**
 
     Before running tests, create a local configuration file:
     ```bash
     cp test/config/local.template.json test/config/local.json
     ```
     Then open `test/config/local.json` and replace all placeholder values with your local or test environment settings.
-4. **Running the tests**
+5. **Running the tests**
     
     To execute the test suite:
     ```bash

--- a/test/copy-toolchain/tf-import.test.js
+++ b/test/copy-toolchain/tf-import.test.js
@@ -1,6 +1,6 @@
 /**
  * Licensed Materials - Property of IBM
- * (c) Copyright IBM Corporation 2025. All Rights Reserved.
+ * (c) Copyright IBM Corporation 2025, 2026. All Rights Reserved.
  *
  * Note to U.S. Government Users Restricted Rights:
  * Use, duplication or disclosure restricted by GSA ADP Schedule
@@ -93,7 +93,7 @@ describe('copy-toolchain: Test import-terraform output', function () {
                     ibm_cd_tekton_pipeline_trigger: 1,
                     ibm_cd_tekton_pipeline_trigger_property: 1,
                     ibm_cd_toolchain: 1,
-                    ibm_cd_toolchain_tool_custom: 1,
+                    ibm_cd_toolchain_tool_cos: 1,
                     ibm_cd_toolchain_tool_devopsinsights: 1,
                     ibm_cd_toolchain_tool_hostedgit: 1,
                     ibm_cd_toolchain_tool_pipeline: 1,

--- a/test/data/test-toolchains.js
+++ b/test/data/test-toolchains.js
@@ -15,38 +15,28 @@ export const TEST_TOOLCHAINS = {
     },
     'misconfigured': {
         name: 'KEEP-MISCONFIGURED-TOOLCHAIN',
-        crn: 'crn:v1:bluemix:public:toolchain:eu-es:a/9e8559fac61ee9fc74d3e595fa75d147:0ccfaa70-ca90-47db-8246-f4ecfc6ad8f3::',
-        region: 'eu-es'
+        crn: 'crn:v1:bluemix:public:toolchain:eu-gb:a/9e8559fac61ee9fc74d3e595fa75d147:128b55a7-56c3-4cc0-87f7-abb24ff0fc6a::',
+        region: 'eu-gb'
     },
     '1pl-ghe-cc': {
         name: 'KEEP-1PL-GHE-CC',
-        crn: 'crn:v1:bluemix:public:toolchain:eu-es:a/9e8559fac61ee9fc74d3e595fa75d147:9d51bb6b-f659-4ab7-9bc4-2eae1d61f4e7::',
-        region: 'eu-es'
+        crn: 'crn:v1:bluemix:public:toolchain:eu-de:a/9e8559fac61ee9fc74d3e595fa75d147:6d75fa57-4eb0-4654-a664-58233ee2aad2::',
+        region: 'eu-de'
     },
     '1pl-ghe-cd': {
         name: 'KEEP-1PL-GHE-CD',
-        crn: 'crn:v1:bluemix:public:toolchain:eu-es:a/9e8559fac61ee9fc74d3e595fa75d147:6a70313f-a927-4b0e-8471-70f17330998d::',
-        region: 'eu-es'
+        crn: 'crn:v1:bluemix:public:toolchain:eu-de:a/9e8559fac61ee9fc74d3e595fa75d147:34df7ab1-bb87-4c34-bf72-1e83d04b0999::',
+        region: 'eu-de'
     },
     '1pl-ghe-ci': {
         name: 'KEEP-1PL-GHE-CI',
-        crn: 'crn:v1:bluemix:public:toolchain:eu-es:a/9e8559fac61ee9fc74d3e595fa75d147:6b8e27ae-5924-4a38-8819-f405366cb900::',
-        region: 'eu-es'
-    },
-    'devsecops-grit-cc': {
-        name: 'KEEP-DevSecOps-GRIT-CC',
-        crn: 'crn:v1:bluemix:public:toolchain:eu-es:a/9e8559fac61ee9fc74d3e595fa75d147:920f6a94-4c1b-412b-b95c-baf823958744::',
-        region: 'eu-es'
-    },
-    'devsecops-grit-cd': {
-        name: 'KEEP-DevSecOps-GRIT-CD',
-        crn: 'crn:v1:bluemix:public:toolchain:eu-es:a/9e8559fac61ee9fc74d3e595fa75d147:8618565f-08fa-4cac-9250-029cac7b41ba::',
-        region: 'eu-es'
+        crn: 'crn:v1:bluemix:public:toolchain:eu-de:a/9e8559fac61ee9fc74d3e595fa75d147:7769bb82-0ef5-4b5d-92c1-5089ac7ff385::',
+        region: 'eu-de'
     },
     'devsecops-grit-ci': {
         name: 'KEEP-DevSecOps-GRIT-CI',
-        crn: 'crn:v1:bluemix:public:toolchain:eu-es:a/9e8559fac61ee9fc74d3e595fa75d147:cdc271bc-cc07-4a85-beb2-895e033319b0::',
-        region: 'eu-es'
+        crn: 'crn:v1:bluemix:public:toolchain:eu-de:a/9e8559fac61ee9fc74d3e595fa75d147:1befe39f-e278-439b-a59a-fb16f14119c3::',
+        region: 'eu-de'
     },
     'single-pl': {
         name: 'KEEP-SINGLE-PIPELINE-TOOLCHAIN',


### PR DESCRIPTION
- Use test toolchains in eu-de instead of eu-es, which is no longer available
- Add tip for running tests locally on macos, workaround for issue in node-pty